### PR TITLE
Change encoder filter to process large jumps

### DIFF
--- a/motor_nucleo/Core/Inc/main.h
+++ b/motor_nucleo/Core/Inc/main.h
@@ -86,6 +86,7 @@ void HAL_TIM_MspPostInit(TIM_HandleTypeDef *htim);
 void Error_Handler(void);
 
 /* USER CODE BEGIN EFP */
+float fabs(float);
 
 /* USER CODE END EFP */
 

--- a/motor_nucleo/Core/Inc/main.h
+++ b/motor_nucleo/Core/Inc/main.h
@@ -59,7 +59,6 @@ typedef struct{
 	uint16_t quad_enc_raw_now;
 	uint16_t quad_enc_raw_last;
 
-	float abs_enc_value_last;
 	float integrated_error;
 	float last_error;
 
@@ -162,6 +161,7 @@ void Error_Handler(void);
 #define ENCODER_ERROR_THRESHOLD 0.1
 #define STABILIZER_BAD_MULTIPLIER 0.97
 #define STABILIZER_MULTIPLIER 0.5
+#define STABILIZER_EPSILON 0.000001
 /* USER CODE END Private defines */
 
 #ifdef __cplusplus

--- a/motor_nucleo/Core/Inc/main.h
+++ b/motor_nucleo/Core/Inc/main.h
@@ -159,7 +159,9 @@ void Error_Handler(void);
 #define J_I2C_SDA_Pin GPIO_PIN_9
 #define J_I2C_SDA_GPIO_Port GPIOB
 /* USER CODE BEGIN Private defines */
-
+#define ENCODER_ERROR_THRESHOLD 0.1
+#define STABILIZER_BAD_MULTIPLIER 0.97
+#define STABILIZER_MULTIPLIER 0.5
 /* USER CODE END Private defines */
 
 #ifdef __cplusplus

--- a/motor_nucleo/Core/Src/main.c
+++ b/motor_nucleo/Core/Src/main.c
@@ -20,6 +20,7 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
+#include <math.h>
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -106,8 +107,17 @@ void updateQuadEnc() {
 float absEncFilter(int channel, float raw_val)
 {
 	// TODO make filters that can handle wrap around
-	(channels + channel)->abs_enc_value_last = (channels + channel)->abs_enc_value;
-	return (raw_val * 0.7) + (0.3 * (channels + channel)->abs_enc_value_last);
+
+  float multiplier = 1;
+
+  if (fabs(raw_val - (channels + channel)->abs_enc_value) > 0.1) {  // TODO set 0.1 as constant ENCODER_ERROR_THRESHOLD
+    multiplier = 0.97;                                              // TODO set 0.97 as constant STABILIZER_BAD_MULTIPLIER
+  }
+  else {
+    multiplier = 0.5;                                               // TODO set 0.5 as constant STABILIZER_MULTIPLIER
+  }
+  
+  return multiplier * (channels + channel)->abs_enc_value + (1 - multiplier) * raw_val;
 }
 
 void updateAbsEnc() {

--- a/motor_nucleo/Core/Src/main.c
+++ b/motor_nucleo/Core/Src/main.c
@@ -20,7 +20,6 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
-#include <math.h>
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -110,11 +109,11 @@ float absEncFilter(int channel, float raw_val)
 
   float multiplier = 1;
 
-  if (fabs(raw_val - (channels + channel)->abs_enc_value) > 0.1) {  // TODO set 0.1 as constant ENCODER_ERROR_THRESHOLD
-    multiplier = 0.97;                                              // TODO set 0.97 as constant STABILIZER_BAD_MULTIPLIER
+  if (fabs(raw_val - (channels + channel)->abs_enc_value) > ENCODER_ERROR_THRESHOLD) {
+    multiplier = STABILIZER_BAD_MULTIPLIER;
   }
   else {
-    multiplier = 0.5;                                               // TODO set 0.5 as constant STABILIZER_MULTIPLIER
+    multiplier = STABILIZER_MULTIPLIER;
   }
   
   return multiplier * (channels + channel)->abs_enc_value + (1 - multiplier) * raw_val;

--- a/motor_nucleo/Core/Src/main.c
+++ b/motor_nucleo/Core/Src/main.c
@@ -107,8 +107,12 @@ float absEncFilter(int channel, float raw_val)
 {
 	// TODO make filters that can handle wrap around
 
-  float multiplier = 1;
+  if (fabs((channels + channel)->abs_enc_value) < STABILIZER_EPSILON) {
+    return raw_val;
+  }
 
+  float multiplier = 1;
+  
   if (fabs(raw_val - (channels + channel)->abs_enc_value) > ENCODER_ERROR_THRESHOLD) {
     multiplier = STABILIZER_BAD_MULTIPLIER;
   }
@@ -268,7 +272,6 @@ int main(void)
 	  channels[i].quad_enc_raw_now = 0;
 	  channels[i].quad_enc_raw_last = 0;
 	  channels[i].abs_enc_value = 0;
-	  channels[i].abs_enc_value_last = 0;
   }
 
   i2c_bus = i2c_bus_default;

--- a/motor_nucleo/Core/Src/main.c
+++ b/motor_nucleo/Core/Src/main.c
@@ -48,7 +48,6 @@ Channel channelDefault = {
 	0, //pwmOutput
 	0, //quadEncRawNow
 	0, //quadEncRawLast
-	0, //absEncValLast
 	0, //integratedError
 	0 //lastError
 };


### PR DESCRIPTION
Encoder filter will take the weighted average of the previous and incoming encoder values, and set that as the encoder value. Currently set to 50% of each. If there's a large jump in encoder values (considered a bad value), it will take 97% of the previous encoder value.